### PR TITLE
[FIX] odoo-storybook: missing icon

### DIFF
--- a/views/storybook_menus.xml
+++ b/views/storybook_menus.xml
@@ -2,9 +2,10 @@
 <odoo>
     <data>
         <menuitem name="Storybook"
-            id="menu_root_storybook"
-            action="storybook_open"
-            web_icon="storybook,static/description/icon.png"
+                  id="menu_root_storybook"
+                  action="storybook_open"
+                  web_icon="odoo-storybook,static/description/icon.png"
+                  sequence="0"
         />
     </data>
 </odoo>


### PR DESCRIPTION
Before this PR the menu icon was missing, by correcting the web_icon in the main menu item the icon reappears.