### PR TITLE
[IMP] props: interface for selecting props dynamically

### DIFF
--- a/static/src/js/canvas/component_renderer.js
+++ b/static/src/js/canvas/component_renderer.js
@@ -6,11 +6,19 @@ import { useStories } from "../stories";
 export class ComponentRenderer extends Component {
     static template = xml`
         <t t-if="stories.active.component">
-            <t t-component="stories.active.component"/>
+            <t t-component="stories.active.component" t-props="storyProps"/>
         </t>
     `;
 
     setup() {
         this.stories = useStories();
+    }
+
+    get storyProps() {
+        const finalProps = {};
+        for (const [propName, config] of Object.entries(this.stories.active.processedProps)) {
+            finalProps[propName] = config.value;
+        }
+        return finalProps;
     }
 }

--- a/static/src/js/panel/panel.js
+++ b/static/src/js/panel/panel.js
@@ -1,0 +1,19 @@
+/** @odoo-module **/
+
+import { Component, useState } from "@odoo/owl";
+import { useStories } from "../stories";
+import { Props } from "../props/props";
+
+export class Panel extends Component {
+    static template = "ui_playground.panel";
+    static components = { Props };
+
+    setup() {
+        this.stories = useStories();
+        this.state = useState({ mode: "props" });
+    }
+
+    changeMode(mode) {
+        this.state.mode = mode;
+    }
+}

--- a/static/src/js/panel/panel.scss
+++ b/static/src/js/panel/panel.scss
@@ -1,0 +1,8 @@
+.o_ui_playground_panel {
+    bottom: 0px;
+    height: 350px; // TODO: make it dynamic with handle
+}
+
+.nav-link.active {
+    font-weight: 600;
+}

--- a/static/src/js/panel/panel.xml
+++ b/static/src/js/panel/panel.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<templates>
+    <t t-name="ui_playground.panel" owl="1">
+        <div class="o_ui_playground_panel border-top w-100 position-absolute d-flex flex-column">
+            <ul class="nav nav-tabs">
+                <li class="nav-item">
+                    <a t-attf-class="nav-link {{state.mode === 'props' ? 'active' : ''}}" class="nav-link" aria-current="page" href="#" t-on-click="() => this.changeMode('props')">Props</a>
+                </li>
+                <li class="nav-item">
+                    <a t-attf-class="nav-link {{state.mode === 'code' ? 'active': ''}}" t-on-click="() => this.changeMode('code')" href="#">Code</a>
+                </li>
+            </ul>
+
+            <t t-if="state.mode === 'props'">
+                <Props/>
+            </t>
+        </div>
+    </t>
+</templates>

--- a/static/src/js/props/props.js
+++ b/static/src/js/props/props.js
@@ -1,0 +1,16 @@
+/** @odoo-module **/
+
+import { Component } from "@odoo/owl";
+import { useStories } from "../stories";
+
+export class Props extends Component {
+    static template = "ui_playground.props";
+
+    setup() {
+        this.stories = useStories();
+    }
+
+    get storyProps() {
+        return this.stories.active?.processedProps || {};
+    }
+}

--- a/static/src/js/props/props.xml
+++ b/static/src/js/props/props.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<templates>
+    <t t-name="ui_playground.props" owl="1">
+        <div class="table-responsive">
+            <table class="table table-sm table-hover table-striped">
+                <thead>
+                    <tr>
+                    <th scope="col">Props Name</th>
+                    <th scope="col">Type</th>
+                    <th scope="col">Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <t t-foreach="storyProps" t-as="props" t-key="props">
+                        <tr>
+                            <td t-esc="props"/>
+                            <td t-esc="props_value.type.name"/>
+                            <td>
+                                <t t-call="ui_playground.props.input"/>
+                            </td>
+                        </tr>
+                    </t>
+                </tbody>
+            </table>
+        </div>
+    </t>
+
+    <t t-name="ui_playground.props.input" owl="1">
+        <t t-if="props_value.type.name === 'Boolean'">
+            <input t-att-disabled="!props_value.dynamic" class="o_input" t-att-checked="props_value.value" type="checkbox" t-model="props_value.value"></input>
+        </t>
+        <t t-elif="props_value.type.name === 'String'">
+            <input t-att-disabled="!props_value.dynamic" class="o_input" t-att-value="props_value.value" t-model="props_value.value"></input>
+        </t>
+
+        <t t-else="">
+            <input t-att-disabled="1" class="o_input" value="wip?"></input>
+        </t>
+    </t>
+</templates>

--- a/static/src/js/sidebar/sidebar.xml
+++ b/static/src/js/sidebar/sidebar.xml
@@ -45,7 +45,7 @@
                         <button class="btn btn-link p-0">
                             <i class="fa fa-bookmark"></i>
                         </button>
-                        <t t-esc="story.name"/>
+                        <t t-esc="story.title"/>
                     </div>
                 </li>
             </ul>

--- a/static/src/js/stories.js
+++ b/static/src/js/stories.js
@@ -37,6 +37,7 @@ export class Stories {
 
     setActive(story) {
         this.active = story;
+        this.setupProps(story);
     }
 
     addStory(moduleName, folder, story) {
@@ -48,8 +49,30 @@ export class Stories {
         }
         this.stories[moduleName]["folders"][folder].stories.push({
             id: this.counter++,
-            name: story.title,
-            component: story,
+            ...story,
         });
+    }
+
+    setupProps(story) {
+        // Props static definition
+        const propsDefinition = story.component.props;
+        // props story configuration
+        const propsStoryConfig = story.props;
+        story.processedProps = {};
+
+        for (const [propName, value] of Object.entries(propsDefinition)) {
+            story.processedProps[propName] = {};
+            const propsStoryObject = story.processedProps[propName];
+            propsStoryObject.type = value.type;
+            propsStoryObject.value = value.default;
+            propsStoryObject.optional = value.optional || false;
+
+            if (propsStoryConfig && propName in propsStoryConfig) {
+                propsStoryObject.dynamic = propsStoryConfig[propName].dynamic || false;
+                if ("default" in propsStoryConfig[propName]) {
+                    propsStoryObject.value = propsStoryConfig[propName].default;
+                }
+            }
+        }
     }
 }

--- a/static/src/js/ui_playground_view.js
+++ b/static/src/js/ui_playground_view.js
@@ -2,6 +2,7 @@
 
 import { Sidebar } from "./sidebar/sidebar";
 import { Canvas } from "./canvas/canvas";
+import { Panel } from "./panel/panel";
 import { Component } from "@odoo/owl";
 import { setupStories } from "./stories";
 import { registry } from "@web/core/registry";
@@ -12,6 +13,6 @@ export class UIPlaygroundView extends Component {
 }
 
 UIPlaygroundView.template = "ui_playground.UiPlaygroundView";
-UIPlaygroundView.components = { Sidebar, Canvas };
+UIPlaygroundView.components = { Sidebar, Canvas, Panel };
 
 registry.category("actions").add("ui_playground_view", UIPlaygroundView);

--- a/static/src/js/ui_playground_view.xml
+++ b/static/src/js/ui_playground_view.xml
@@ -4,10 +4,10 @@
         <div class="d-sm-flex flex-row h-100 ">
 
             <Sidebar stories="stories.stories"/>
-            <div class="d-flex flex-column bg-white w-100 h-100" style="width:100px">
+            <div class="d-flex flex-column bg-white w-100 h-100 position-relative" style="width:100px">
                 <div class="o_ui_playground_topbar text-light w-100">
                     <div class="d-flex flex-row justify-content-between border-bottom align-items-center">
-                        <span class="p-3"> <t t-esc="stories.active.name"/> </span>
+                        <span class="p-3"> <t t-esc="stories.active.title"/> </span>
                         <div class="d-flex flex-row">
                             <button class="btn text-light"> Canvas </button>
                             <button class="btn text-light"> Documentation </button>
@@ -16,6 +16,7 @@
                 </div>
 
                 <Canvas/>
+                <Panel/>
             </div>
         </div>
 

--- a/static/src/stories/autocomplete/autocomplete.stories.js
+++ b/static/src/stories/autocomplete/autocomplete.stories.js
@@ -2,39 +2,44 @@
 
 import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 import { registry } from "@web/core/registry";
-const { Component, xml } = owl;
 
-class StoryA extends Component {
-    static template = xml`
-        <AutoComplete
-            value="''"
-            sources="sources"
-            placeholder="'Search order by customer ...'"
-            autoSelect="false"
-            onSelect.bind="onSelect"
-        />
-    `;
-    static components = { AutoComplete };
-    static title = "Autocomplete";
-
-    get sources() {
-        return [
-            {
-                placeholder: "Loading...",
-                options: [{ label: "First choice" }, { label: "Second choice" }],
-            },
-        ];
-    }
-
-    onSelect(option) {
-        console.log(`${option.label} selected`);
-    }
-}
+const storyA = {
+    title: "Autocomplete",
+    component: AutoComplete,
+    props: {
+        value: {
+            default: "",
+            dynamic: true,
+        },
+        sources: {
+            default: [
+                {
+                    placeholder: "Loading...",
+                    options: [{ label: "First choice" }, { label: "Second choice" }],
+                },
+            ],
+        },
+        placeholder: {
+            default: "Search order by customer ...",
+            dynamic: true,
+        },
+        autoSelect: {
+            default: false,
+        },
+        onSelect: {
+            default: () => console.log("Select event"),
+        },
+        resetOnSelect: {
+            default: true,
+            dynamic: true,
+        },
+    },
+};
 
 export const AutocompleteStories = {
     title: "Autocomplete",
     module: "web",
-    stories: [StoryA],
+    stories: [storyA],
 };
 
 registry.category("stories").add("ui_playground.autocomplete", AutocompleteStories);

--- a/static/src/stories/checkbox/checkbox.stories.js
+++ b/static/src/stories/checkbox/checkbox.stories.js
@@ -2,24 +2,54 @@
 
 import { CheckBox } from "@web/core/checkbox/checkbox";
 import { registry } from "@web/core/registry";
-const { Component, xml } = owl;
 
-class StoryA extends Component {
-    static template = xml`<CheckBox/>`;
-    static components = { CheckBox };
-    static title = "Checkbox first story";
-}
+const storyA = {
+    title: "CheckboxFirstStory",
+    component: CheckBox,
+    props: {
+        disabled: {
+            dynamic: true,
+            default: true,
+        },
+        value: {
+            dynamic: true,
+            default: true,
+        },
+        className: {
+            dynamic: true,
+            default: "form-switch",
+        },
+        name: {
+            default: "beautiful_name",
+        },
+    },
+};
 
-class StoryB extends Component {
-    static template = xml`<CheckBox/>`;
-    static components = { CheckBox };
-    static title = "Checkbox second story";
-}
+const storyB = {
+    title: "CheckboxSecondStory",
+    component: CheckBox,
+    props: {
+        disabled: {
+            dynamic: true,
+            default: false,
+        },
+        value: {
+            dynamic: true,
+            default: true,
+        },
+        className: {
+            dynamic: true,
+        },
+        name: {
+            default: "beautiful_name",
+        },
+    },
+};
 
 export const CheckBoxStories = {
     title: "Checkbox",
     module: "web",
-    stories: [StoryA, StoryB],
+    stories: [storyA, storyB],
 };
 
 registry.category("stories").add("ui_playground.checkbox", CheckBoxStories);


### PR DESCRIPTION
This commit introduces a props panel that allows users to interact with props dynamically. The panel allows users to modify the values of props on the fly, without the need to restart the application. This provides a more seamless and efficient experience for users when working with props in the application.

The supported props for dynamic modification are for the moment `String` and `Boolean`. Other type of props will be implemented in the future.

This commit also change the way stories are represented. Before a story was a `Component` class that rendered the component, with static objects to represent the story metadata.
Now a story is a simple object where each attribute represent the story metadata.

![chrome-capture-2022-11-16](https://user-images.githubusercontent.com/109217759/208189472-733af069-9841-4b62-8e30-98e289de6e43.gif)
