### PR TITLE
[IMP] Move ui_playground to a Controller

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -27,13 +27,74 @@
         'views/ui_playground_menus.xml',
     ],
     'assets': {
+        'ui_playground.assets_ui_playground': [
+            'ui_playground/static/src/js/main.js',
+        ],
         'web.assets_backend': [
             'ui_playground/static/src/js/**/*',
+            ('remove', 'ui_playground/static/src/js/main.js'),
             'ui_playground/static/src/stories/**/*',
         ],
         'web.tests_assets': [
             'ui_playground/static/tests/**/*',
-        ]
+        ],
+         'ui_playground.tests_assets_copy': [
+            # If we have time, assets must be refactored to only include what we need maybe
+            # This is a copy of tests_assets without the tests added by other module
+            'web/static/lib/qunit/qunit-2.9.1.css',
+            'web/static/lib/qunit/qunit-2.9.1.js',
+            'web/static/tests/legacy/helpers/**/*',
+            ('remove', 'web/static/tests/legacy/helpers/test_utils_tests.js'),
+            'web/static/tests/legacy/legacy_setup.js',
+
+            # 'web/static/lib/fullcalendar/core/main.css',
+            # 'web/static/lib/fullcalendar/daygrid/main.css',
+            # 'web/static/lib/fullcalendar/timegrid/main.css',
+            # 'web/static/lib/fullcalendar/list/main.css',
+            # 'web/static/lib/fullcalendar/core/main.js',
+            # 'web/static/lib/fullcalendar/moment/main.js',
+            # 'web/static/lib/fullcalendar/interaction/main.js',
+            # 'web/static/lib/fullcalendar/daygrid/main.js',
+            # 'web/static/lib/fullcalendar/timegrid/main.js',
+            # 'web/static/lib/fullcalendar/list/main.js',
+            # 'web/static/lib/fullcalendar/luxon/main.js',
+
+            # 'web/static/lib/ace/ace.js',
+            # 'web/static/lib/ace/javascript_highlight_rules.js',
+            # 'web/static/lib/ace/mode-python.js',
+            # 'web/static/lib/ace/mode-xml.js',
+            # 'web/static/lib/ace/mode-js.js',
+            # 'web/static/lib/ace/mode-qweb.js',
+            # 'web/static/lib/nearest/jquery.nearest.js',
+            # 'web/static/lib/daterangepicker/daterangepicker.js',
+            # 'web/static/src/legacy/js/libs/daterangepicker.js',
+            # 'web/static/lib/stacktracejs/stacktrace.js',
+            # 'web/static/lib/Chart/Chart.js',
+
+            # '/web/static/lib/daterangepicker/daterangepicker.js',
+
+            # 'web/static/tests/legacy/main_tests.js',
+            'web/static/tests/helpers/**/*.js',
+            # 'web/static/tests/views/helpers.js',
+            # 'web/static/tests/search/helpers.js',
+            # 'web/static/tests/views/calendar/helpers.js',
+            # 'web/static/tests/webclient/**/helpers.js',
+            # 'web/static/tests/qunit.js',
+            # 'web/static/tests/main.js',
+            # 'web/static/tests/mock_server_tests.js',
+            # 'web/static/tests/setup.js',
+
+            # # These 2 lines below are taken from web.assets_frontend
+            # # They're required for the web.frontend_legacy to work properly
+            # # It is expected to add other lines coming from the web.assets_frontend
+            # # if we need to add more and more legacy stuff that would require other scss or js.
+            # ('include', 'web._assets_helpers'),
+            # 'web/static/src/scss/pre_variables.scss',
+            # 'web/static/lib/bootstrap/scss/_variables.scss',
+
+            # ('include', 'web.frontend_legacy'),
+            # ("include", "web.assets_backend_legacy_lazy"),
+        ],
     },
     'application': True,
 }

--- a/static/src/js/main.js
+++ b/static/src/js/main.js
@@ -1,16 +1,17 @@
-// TODO
-// /** @odoo-module **/
+/** @odoo-module **/
 
-// import { mount } from "@odoo/owl";
-// import { UIPlaygroundView } from "./ui_playground_view";
+import { mount } from "@odoo/owl";
+import { UIPlaygroundView } from "./ui_playground_view";
+import { makeEnv, startServices } from "@web/env";
+// The following code ensures that owl mount the component when ready.
+// `templates` contains templates contained in the bundles.
+//
+// In the mount options, it's also possible to add other interresting
+// configuration: https://github.com/odoo/owl/blob/master/doc/reference/app.md#configuration
+import { templates } from "@web/core/assets";
 
-// // The following code ensures that owl mount the component when ready.
-// // `templates` contains templates contained in the bundles.
-// //
-// // In the mount options, it's also possible to add other interresting 
-// // configuration: https://github.com/odoo/owl/blob/master/doc/reference/app.md#configuration
-// import { templates } from "@web/core/assets";
-
-// owl.whenReady( () => {
-//     mount(UIPlaygroundView, document.body, { templates });
-// });
+owl.whenReady(async () => {
+    const env = makeEnv();
+    await startServices(env);
+    mount(UIPlaygroundView, document.body, { templates, env });
+});

--- a/views/ui_playground_views.xml
+++ b/views/ui_playground_views.xml
@@ -5,5 +5,21 @@
             <field name="tag">ui_playground_view</field>
             <field name="target">main</field>
         </record>
+
+        <template id="ui_playground.ui_playground" name="Storybook">
+
+            <t t-call="web.layout">
+                <t t-set="html_data" t-value="{'style': 'height: 100%;'}"/>
+                <t t-set="title">UI Playground</t>
+                <t t-set="head">
+                    <t t-call-assets="web.assets_common" t-js="false"/>
+                    <t t-call-assets="web.assets_backend" t-js="false"/>
+                    <t t-call-assets="web.assets_common" t-css="false"/>
+                    <t t-call-assets="web.assets_backend" t-css="false"/>
+                    <t t-call-assets="ui_playground.assets_ui_playground"/>
+                    <t t-call-assets="ui_playground.tests_assets_copy"/>
+                </t>
+            </t>
+        </template>
     </data>
 </odoo>


### PR DESCRIPTION
By moving the ui_playground into a controller, external users will be able to access the app without logging in. 
Additionally, this may also enable the integration of the ui_playground's UI via an iframe on other websites.