### PR TITLE
[IMP] show Object and Array in props

### DIFF
--- a/static/src/js/bottom_panel/component_properties/props.js
+++ b/static/src/js/bottom_panel/component_properties/props.js
@@ -2,16 +2,25 @@
 
 import { Component } from "@odoo/owl";
 import { useStories } from "../../stories";
-
+import { ObjectRenderer } from "../../components/object_renderer/object_renderer";
 export class Props extends Component {
     static template = "ui_playground.properties";
+    static components = { ObjectRenderer };
 
     setup() {
         this.stories = useStories();
     }
 
     propertyType(props) {
-        const str = props?.type?.name || typeof props.value;
+        const propsValidationType = props?.type?.name;
+
+        if (propsValidationType) {
+            return props.type.name;
+        }
+        if (Array.isArray(props.value)) {
+            return "Array";
+        }
+        const str = typeof props.value;
         return str.charAt(0).toUpperCase() + str.slice(1);
     }
 

--- a/static/src/js/bottom_panel/properties.xml
+++ b/static/src/js/bottom_panel/properties.xml
@@ -32,14 +32,35 @@
     </t>
 
     <t t-name="ui_playground.properties.input" owl="1">
-        <t t-if="propertyType(property_value) === 'Boolean'">
-            <input t-att-disabled="isDisabled(property_value)" class="o_input" t-att-checked="formatValue(propertyType(property_value), property_value.value)" type="checkbox" t-on-change="(ev) => this.onChange(property_value, ev.target.checked)"/>
+        <t t-set="propType" t-value="propertyType(property_value)"/>
+        <t t-set="propValue" t-value="formatValue(propType, property_value.value)"/>
+        <t t-if="propType === 'Boolean'">
+            <input t-att-disabled="isDisabled(property_value)" class="o_input" t-att-checked="propValue" type="checkbox" t-on-change="(ev) => this.onChange(property_value, ev.target.checked)"/>
         </t>
-        <t t-elif="propertyType(property_value) === 'String'">
-            <input t-att-disabled="isDisabled(property_value)" class="o_input o_outline" t-att-value="formatValue(propertyType(property_value), property_value.value)" t-on-input="(ev) => this.onChange(property_value, ev.target.value)"/>
+        <t t-elif="propType === 'String'">
+            <input t-att-disabled="isDisabled(property_value)" class="o_input o_outline" t-att-value="propValue" t-on-input="(ev) => this.onChange(property_value, ev.target.value)"/>
         </t>
-        <t t-elif="propertyType(property_value) === 'Number'">
-            <input t-att-disabled="isDisabled(property_value)" class="o_input o_outline" t-att-value="formatValue(propertyType(property_value), property_value.value)" t-on-change="(ev) => this.onChange(property_value, ev.target.value)"/>
+        <t t-elif="propType === 'Number'">
+            <input t-att-disabled="isDisabled(property_value)" class="o_input o_outline" t-att-value="propValue" t-on-change="(ev) => this.onChange(property_value, ev.target.value)"/>
+        </t>
+        <t t-elif="propType === 'Object'">
+            <t t-if="propValue">
+                <ObjectRenderer object="propValue" name="property"/>
+            </t>
+            <t t-else="">
+                undefined
+            </t>
+        </t>
+        <t t-elif="propType === 'Array'">
+            <t t-if="propValue">
+                <ObjectRenderer object="propValue" name="property"/>
+            </t>
+            <t t-else="">
+                undefined
+            </t>
+        </t>
+        <t t-elif="propType === 'Function'">
+            Function
         </t>
         <t t-else="">
             <input t-att-disabled="1" class="o_input" value="wip?"/>

--- a/static/src/js/components/object_renderer/object_renderer.js
+++ b/static/src/js/components/object_renderer/object_renderer.js
@@ -1,0 +1,35 @@
+/** @odoo-module */
+
+import { Component, useState } from "@odoo/owl";
+
+export class ObjectRenderer extends Component {
+    static template = "ui_playground.ObjectRenderer";
+
+    setup() {
+        this.uncollapsed = useState({});
+    }
+
+    isObject(value) {
+        return typeof value === "object";
+    }
+
+    isArray(value) {
+        return Array.isArray(value);
+    }
+
+    openingBracket(object) {
+        return this.isArray(object) ? "[" : "{";
+    }
+
+    closingBracket(object) {
+        return this.isArray(object) ? "]" : "}";
+    }
+
+    toggleCollapse(uncollapsedObject, name) {
+        if (uncollapsedObject[name]) {
+            uncollapsedObject[name] = undefined;
+        } else {
+            uncollapsedObject[name] = {};
+        }
+    }
+}

--- a/static/src/js/components/object_renderer/object_renderer.xml
+++ b/static/src/js/components/object_renderer/object_renderer.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+
+    <t t-name="ui_playground.ObjectRenderer" owl="1">
+        <t t-set="name" t-value="props.name"/>
+        <t t-set="object" t-value="props.object"/>
+        <t t-set="uncollapsedObject" t-value="uncollapsed"
+        <t t-call="ui_playground.ObjectRenderer.object"/>
+    </t>
+
+    <t t-name="ui_playground.ObjectRenderer.object" owl="1">
+        <t t-if="object and isObject(object)">
+            <span t-on-click="() => toggleCollapse(uncollapsedObject, name)" class="o_ui_playground_hover">
+                <i t-if="uncollapsedObject[name]" class="fa fa-caret-down"></i>
+                <i t-else="" class="fa fa-caret-right"></i>
+                <span> <t t-esc="name"/>: </span>
+                <span class="text-muted" t-if="!uncollapsedObject[name]">
+                    <t t-esc="openingBracket(object)"/>...<t t-esc="closingBracket(object)"/> <t t-esc="Object.keys(object).length"/> items
+                </span>
+                <t t-if="uncollapsedObject[name]" t-esc="openingBracket(object)"/>
+            </span>
+            <t t-if="uncollapsedObject[name]">
+                <ul class="m-0">
+                    <t t-foreach="Object.keys(object)" t-as="subObject" t-key="subObject">
+                        <li class="ms-4">
+                            <t t-call="ui_playground.ObjectRenderer.object">
+                                <t t-set="uncollapsedObject" t-value="uncollapsedObject[name]"/>
+                                <t t-set="name" t-value="subObject"/>
+                                <t t-set="object" t-value="object[subObject]"/>
+                            </t>
+                        </li>
+                    </t>
+                </ul>
+                <t t-esc="closingBracket(object)"/>
+            </t>
+        </t>
+        <t t-else="">
+            <span> <t t-esc="name"/>: </span>
+            <t t-esc="object"/>
+        </t>
+    </t>
+</templates>


### PR DESCRIPTION
This commit introduces objects and arrays in component properties
tab. It shows object and array element recursively, user can also fold
and unfold elements.

For the moment it is only in readonly, but we could imagine a next feature where we can modify it


![chrome-capture-2023-1-24](https://user-images.githubusercontent.com/109217759/221220889-86d765e4-26f2-4927-86c3-b2a2a1412de8.gif)
