### PR TITLE
Remove introduction hash from url & linting

### DIFF
--- a/static/src/js/sidebar/sidebar.js
+++ b/static/src/js/sidebar/sidebar.js
@@ -9,8 +9,8 @@ export class Sidebar extends Component {
         this.filterName = "";
         this.map = this.getAllStories();
         this.all = this.getStoriesAndFolder();
-        this.filteredStories = useState([ ...this.all[0] ]);
-        this.filteredFolders = useState([ ...this.all[1] ]);
+        this.filteredStories = useState([...this.all[0]]);
+        this.filteredFolders = useState([...this.all[1]]);
     }
 
     /**
@@ -73,7 +73,7 @@ export class Sidebar extends Component {
             res_folder.add(key);
             res_stories.push(value);
         }
-        return [res_stories.flat(), res_folder]
+        return [res_stories.flat(), res_folder];
     }
 
     /**
@@ -85,10 +85,13 @@ export class Sidebar extends Component {
         this.filteredStories.splice(0, this.filteredStories.length);
         this.filteredFolders.splice(0, this.filteredFolders.length);
         for (const [key, value] of this.map) {
-            for(const elem of value) {
-                if (elem.toLowerCase().includes(searchString.toLowerCase()) && !this.filteredStories.includes(elem)) {
+            for (const elem of value) {
+                if (
+                    elem.toLowerCase().includes(searchString.toLowerCase()) &&
+                    !this.filteredStories.includes(elem)
+                ) {
                     this.filteredStories.push(elem);
-                    if(!this.filteredFolders.includes(key)) {
+                    if (!this.filteredFolders.includes(key)) {
                         this.filteredFolders.push(key);
                     }
                 }
@@ -97,8 +100,8 @@ export class Sidebar extends Component {
     }
 
     showIntroduction() {
-         this.stories.resetActive();
-         window.history.pushState(null, '', "ui_playground#introduction");
+        this.stories.resetActive();
+        window.history.pushState(null, "", "ui_playground");
     }
 }
 

--- a/static/src/js/stories.js
+++ b/static/src/js/stories.js
@@ -50,7 +50,7 @@ export class Stories {
         } else if (this.active.attrs) {
             this.setupAttrs(story);
         }
-        this.setUrl(story)
+        this.setUrl(story);
     }
 
     /**
@@ -58,13 +58,13 @@ export class Stories {
      * Also deal with go back function of the browser so that when pressing the button the last story become active
      * @param {Object} story
      */
-    setUrl(story){
-        const fileSystem = [story.moduleName, story.folder, story.title].map(function(current) {
-            current = current.replace(/ /g, '+');//replace all spaces by a + sign
+    setUrl(story) {
+        const fileSystem = [story.moduleName, story.folder, story.title].map((current) => {
+            current = current.replace(/ /g, "+"); //replace all spaces by a + sign
             return current;
         });
-        const url = "ui_playground#module=" + fileSystem[0] + "&folder=" + fileSystem[1] + "&story=" + fileSystem[2];
-        window.history.pushState(null, '', url);
+        const url = `ui_playground#module=${fileSystem[0]}&folder=${fileSystem[1]}&story=${fileSystem[2]}`;
+        window.history.pushState(null, "", url);
     }
 
     /**
@@ -85,14 +85,16 @@ export class Stories {
     }
 
     parseParams(str) {
-        let pieces = str.split("&"), data = {}, i, parts;
+        const pieces = str.split("&");
+        const data = {};
+        let i, parts;
         // process each query pair
         for (i = 0; i < pieces.length; i++) {
             parts = pieces[i].split("=");
             if (parts.length < 2) {
                 parts.push("");
             }
-            data[decodeURIComponent(parts[0])] = decodeURIComponent(parts[1].replace(/\+/g,' '));
+            data[decodeURIComponent(parts[0])] = decodeURIComponent(parts[1].replace(/\+/g, " "));
         }
         return data;
     }

--- a/static/src/js/ui_playground_view.js
+++ b/static/src/js/ui_playground_view.js
@@ -3,30 +3,28 @@
 import { Sidebar } from "./sidebar/sidebar";
 import { Canvas } from "./canvas/canvas";
 import { Panel } from "./bottom_panel/panel";
-import { Component , onMounted , useEffect} from "@odoo/owl";
+import { Component, onMounted } from "@odoo/owl";
 import { setupStories } from "./stories";
 import { registry } from "@web/core/registry";
 
 export class UIPlaygroundView extends Component {
     setup() {
         this.stories = setupStories();
-        this.getUrl();
+        this.setStoryFromUrl();
         onMounted(this.onMounted);
     }
 
     onMounted() {
         window.addEventListener("hashchange", (ev) => {
-            this.getUrl();
+            this.setStoryFromUrl();
         });
     }
 
-    getUrl() {
-        const url = document.URL;
-        const params = this.stories.parseParams(url.substring(url.indexOf("#") + 1, url.length));
-        if (!("introduction" in params)) {
+    setStoryFromUrl() {
+        const hash = window.location.hash;
+        if (hash !== "") {
+            const params = this.stories.parseParams(hash.slice(1));
             this.stories.setActive(this.stories.getStoryByName(params));
-        } else {
-            this.stories.resetActive();
         }
     }
 }


### PR DESCRIPTION
The route `url/ui_playground` crashed because the introduction page
was only accessible on `url/ui_playground#introduction`.

The introduction page is now only accessible from `url/ui_playground`

This commit also do some linting