### PR TITLE
[IMP] differentiate optional property

### DIFF
--- a/static/src/js/bottom_panel/properties.xml
+++ b/static/src/js/bottom_panel/properties.xml
@@ -70,6 +70,7 @@
 
     <t t-name="ui_playground.properties.name" owl="1">
         <t t-esc="property"/>
+        <t t-if="!property_value.optional"><span>*</span></t>
         <i class="fa fa-question-circle-o ps-2 ui_playground_tooltip" t-if="property_value.help" t-att-data-tooltip="property_value.help"/>
     </t>
 </templates>


### PR DESCRIPTION
Property can be optional, to make a better difference between them, we added a "*" to non-optional property