### PR TITLE
[REF & FIX] narrow down the bundle & remove QUnit

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -39,16 +39,13 @@
             'ui_playground/static/src/js/**/*.xml',
             'ui_playground/static/src/stories/**/*',
 
-            'web/static/lib/qunit/qunit-2.9.1.css',
-            'web/static/lib/qunit/qunit-2.9.1.js',
-            'web/static/tests/legacy/helpers/**/*',
-            ('remove', 'web/static/tests/legacy/helpers/test_utils_tests.js'),
+            # next line is required for tour
             'web/static/tests/legacy/legacy_setup.js',
 
             'web/static/tests/helpers/**/*.js',
-            'web/static/tests/views/helpers.js',
-            'web/static/tests/search/helpers.js',
-            'web/static/tests/webclient/**/helpers.js',
+            ('remove', "web/static/tests/helpers/legacy.js"),
+            ('remove', "web/static/tests/helpers/legacy_env_utils.js"),
+            ('remove', "web/static/tests/helpers/mock_env.js"),
         ],
         'web.tests_assets': [
             'ui_playground/static/src/js/**/*.js',

--- a/static/src/js/canvas/arch_renderer.js
+++ b/static/src/js/canvas/arch_renderer.js
@@ -9,6 +9,7 @@ import { View } from "@web/views/view";
 import { ORM } from "@web/core/orm_service";
 import { viewService } from "@web/views/view_service";
 import { createDebugContext } from "@web/core/debug/debug_context";
+
 export class ArchRenderer extends Component {
     static template = xml`
         <div t-if="state.hasError" class="alert alert-warning o_error_detail fw-bold m-auto">

--- a/static/src/js/main.js
+++ b/static/src/js/main.js
@@ -14,5 +14,6 @@ import { templates } from "@web/core/assets";
 owl.whenReady(async () => {
     const env = makeEnv();
     await startServices(env);
+    owl.Component.env.session = {};
     mount(UIPlaygroundView, document.body, { templates, env });
 });

--- a/static/src/js/mock_qunit.js
+++ b/static/src/js/mock_qunit.js
@@ -1,0 +1,14 @@
+/** odoo-module */
+
+// We do not want to include QUnit in the bundle but mock_services and
+// other dependencies from the arch_renderer indirectly needs it. So let's "mock" it.
+const QUnit = {
+    on: () => {},
+    module: (name, options, executeNow) => {
+        // mock_server file is enclosed in a QUnit.module
+        options();
+    },
+    testStart: () => {},
+};
+// @ts-ignore
+document.QUnit = QUnit;


### PR DESCRIPTION
Previously, we didn't removed QUnit from our assets because some files we are using depends on it.
With this commit, QUnit is deleted from our assets and the API is mocked.

I also took the opportunity to narrow down our assets to not include useless files we are not using.

As a side effect from this REF, some errors throwed by QUnit are now fixed.