### PR TITLE
[FIX] fix errors from services & restore tooltip

### DIFF
--- a/static/src/js/main.js
+++ b/static/src/js/main.js
@@ -3,6 +3,11 @@
 import { mount } from "@odoo/owl";
 import { UIPlaygroundView } from "./ui_playground_view";
 import { makeEnv, startServices } from "@web/env";
+import { registry } from "@web/core/registry";
+import {
+    fakeCompanyService,
+    makeFakeLocalizationService,
+} from "@web/../tests/helpers/mock_services";
 
 // The following code ensures that owl mount the component when ready.
 // `templates` contains templates contained in the bundles.
@@ -11,9 +16,27 @@ import { makeEnv, startServices } from "@web/env";
 // configuration: https://github.com/odoo/owl/blob/master/doc/reference/app.md#configuration
 import { templates } from "@web/core/assets";
 
+const serviceRegistry = registry.category("services");
+
 owl.whenReady(async () => {
     const env = makeEnv();
+
+    serviceRegistry.add("localization", makeFakeLocalizationService(), { force: true });
+    serviceRegistry.add("company", fakeCompanyService, { force: true });
+    serviceRegistry.add(
+        "menu",
+        {
+            start() {
+                return {};
+            },
+        },
+        { force: true }
+    );
+
     await startServices(env);
+
+    // @ts-ignore
     owl.Component.env.session = {};
+    // @ts-ignore
     mount(UIPlaygroundView, document.body, { templates, env });
 });

--- a/static/src/js/ui_playground_view.js
+++ b/static/src/js/ui_playground_view.js
@@ -6,6 +6,7 @@ import { Panel } from "./bottom_panel/panel";
 import { Component, onMounted } from "@odoo/owl";
 import { setupStories } from "./stories";
 import { registry } from "@web/core/registry";
+import { MainComponentsContainer } from "@web/core/main_components_container";
 
 export class UIPlaygroundView extends Component {
     setup() {
@@ -30,6 +31,6 @@ export class UIPlaygroundView extends Component {
 }
 
 UIPlaygroundView.template = "ui_playground.UiPlaygroundView";
-UIPlaygroundView.components = { Sidebar, Canvas, Panel };
+UIPlaygroundView.components = { Sidebar, Canvas, Panel, MainComponentsContainer };
 
 registry.category("actions").add("ui_playground_view", UIPlaygroundView);

--- a/static/src/js/ui_playground_view.xml
+++ b/static/src/js/ui_playground_view.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="ui_playground.UiPlaygroundView" owl="1">
+        <MainComponentsContainer/>
         <div class="d-sm-flex flex-row h-100 bg-white">
 
             <Sidebar stories="stories.stories"/>

--- a/views/ui_playground_views.xml
+++ b/views/ui_playground_views.xml
@@ -7,7 +7,6 @@
         </record>
 
         <template id="ui_playground.ui_playground" name="Storybook">
-
             <t t-call="web.layout">
                 <t t-set="html_data" t-value="{'style': 'height: 100%;'}"/>
                 <t t-set="title">UI Playground</t>


### PR DESCRIPTION
Previously, localizationService, companyService and menuService caused
some errors because there is no web session information for our controller.

By faking the services, we get rid of the errors.

This commit also restore tooltips and the popovers.