### PR TITLE
[FIX] fix ui_playground in app switcher

### DIFF
--- a/views/ui_playground_views.xml
+++ b/views/ui_playground_views.xml
@@ -1,9 +1,9 @@
 <odoo>
     <data>
-        <record id="ui_playground_open" model="ir.actions.client">
+        <record id="ui_playground_open" model="ir.actions.act_url">
             <field name="name">UI Playground</field>
-            <field name="tag">ui_playground_view</field>
-            <field name="target">main</field>
+            <field name="url">ui_playground</field>
+            <field name="target">self</field>
         </record>
 
         <template id="ui_playground.ui_playground" name="Storybook">


### PR DESCRIPTION
Previously, the action in the app switch tried to launch the UIPlaygroundView component directly which caused a crash.

Now the action open the ui_playground thanks to the url pointing to the controller.